### PR TITLE
Feature/6 monitoring pool node

### DIFF
--- a/pool/mock_test.go
+++ b/pool/mock_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"errors"
+	"go.uber.org/zap"
 
 	sessionv2 "github.com/TrueCloudLab/frostfs-api-go/v2/session"
 	"github.com/TrueCloudLab/frostfs-sdk-go/accounting"
@@ -33,7 +34,7 @@ type mockClient struct {
 func newMockClient(addr string, key ecdsa.PrivateKey) *mockClient {
 	return &mockClient{
 		key:                 key,
-		clientStatusMonitor: newClientStatusMonitor(addr, 10),
+		clientStatusMonitor: newClientStatusMonitor(zap.NewExample(), addr, 10),
 	}
 }
 

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -1556,7 +1556,7 @@ const (
 	defaultSessionTokenExpirationDuration = 100 // in blocks
 	defaultErrorThreshold                 = 100
 
-	defaultRebalanceInterval  = 25 * time.Second
+	defaultRebalanceInterval  = 15 * time.Second
 	defaultHealthcheckTimeout = 4 * time.Second
 	defaultDialTimeout        = 5 * time.Second
 	defaultStreamTimeout      = 10 * time.Second

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -514,7 +514,7 @@ func TestWaitPresence(t *testing.T) {
 }
 
 func TestStatusMonitor(t *testing.T) {
-	monitor := newClientStatusMonitor("", 10)
+	monitor := newClientStatusMonitor(zap.NewExample(), "", 10)
 	monitor.errorThreshold = 3
 
 	count := 10
@@ -527,7 +527,7 @@ func TestStatusMonitor(t *testing.T) {
 }
 
 func TestHandleError(t *testing.T) {
-	monitor := newClientStatusMonitor("", 10)
+	monitor := newClientStatusMonitor(zap.NewExample(), "", 10)
 
 	for i, tc := range []struct {
 		status        apistatus.Status


### PR DESCRIPTION
close #6 

log example:
```
2023-01-11T16:18:26.215+0300    warn    pool/pool.go:1664       failed to build client  {"address": "s03.frostfs.devenv:8080", "error": "open gRPC connection: gRPC dial: context deadline exceeded"}
2023-01-11T16:18:31.216+0300    warn    pool/pool.go:1664       failed to build client  {"address": "s04.frostfs.devenv:8080", "error": "open gRPC connection: gRPC dial: context deadline exceeded"}
...
2023-01-11T16:19:06.220+0300    debug   pool/pool.go:1662       health has changed      {"address": "s03.frostfs.devenv:8080", "healthy": true}
2023-01-11T16:19:06.221+0300    debug   pool/pool.go:1662       health has changed      {"address": "s04.frostfs.devenv:8080", "healthy": true}
2023-01-11T16:19:26.223+0300    debug   pool/pool.go:1662       health has changed      {"address": "s04.frostfs.devenv:8080", "healthy": false}
2023-01-11T16:19:26.223+0300    debug   pool/pool.go:1662       health has changed      {"address": "s03.frostfs.devenv:8080", "healthy": false}
```