### PR TITLE
.github: drop go1.17, add go1.20

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @alexvanin @fyrchik @cthulhu-rider
+*   @TrueCloudLab/dev

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go_versions: [ '1.17.x', '1.18.x', '1.19.x' ]
+        go_versions: [ '1.18.x', '1.19.x', '1.20.x' ]
       fail-fast: false
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
I hope we will move to pre-commit soon, but the read cross still bothers me.